### PR TITLE
Check for empty media case

### DIFF
--- a/extract-media
+++ b/extract-media
@@ -13,9 +13,13 @@ _extract() {
 
   MEDIA_FILES="$(find "$TMP_DIR/out" \( -name "*.png" -o -name "*.jpg" -o -name "*.mp4" -o -name "*.gif" \))"
 
-  echo "$MEDIA_FILES" | while read -r line; do
-    cp "$line" "$2/"
-  done
+  if [ "$MEDIA_FILES" == "" ]; then
+    echo "No media found"
+  else 
+    echo "$MEDIA_FILES" | while read -r line; do
+      cp "$line" "$2/"
+    done
+  fi
 }
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
I did a test on a docx that had no media (boring lawyer stuff), and it resulted in an error as `cp` tried on the empty string.

This code explicits the failure and avoids the error.